### PR TITLE
Create working dir if it does not exist.

### DIFF
--- a/bin/ddnss-update
+++ b/bin/ddnss-update
@@ -224,6 +224,11 @@ sub get_last_ip {
 
 sub set_last_ip {
   my ($version, $ip) = @_;
+  my $dir = $config->{WORKING_DIR};
+  unless(-e $dir or mkdir $dir) {
+    logmsg("Unable to create $dir");
+    return;
+  }
   my $file = "$config->{WORKING_DIR}/lastip.v$version";
   my $fh;
   if (!open($fh, '>', $file)) {


### PR DESCRIPTION
Reason: Get around the following error:
```
[2019-03-19 14:37:29] WARNING - stat on /var/lib/ddnss/lastip.v4 failed: No such file or directory
[2019-03-19 14:37:29] WARNING - stat on /var/lib/ddnss/lastip.v6 failed: No such file or directory
[2019-03-19 14:37:29] NOTICE  - Update needed, reason: 7
[2019-03-19 14:37:30] WARNING - Could not open '/var/lib/ddnss/lastip.v4': No such file or directory
[2019-03-19 14:37:30] WARNING - Could not open '/var/lib/ddnss/lastip.v6': No such file or directory
[2019-03-19 14:38:50] WARNING - Could not open '/var/lib/ddnss/lastip.v4': No such file or directory
[2019-03-19 14:38:50] WARNING - Could not open '/var/lib/ddnss/lastip.v6': No such file or directory
```